### PR TITLE
Iterate the app

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,3 +1,5 @@
 gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
+gom 'github.com/onsi/ginkgo', :commit => '75d0cd9c7ee52e99b13e6ccfd9e58b4f92b7795e'
+gom 'github.com/onsi/gomega', :commit => '835b5e4242c715976b98ed6bc6ece1d9c7879f66'
 gom 'gopkg.in/mgo.v2', :commit => 'v2'
 gom 'gopkg.in/validator.v2', :commit => 'v2'

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
-.PHONY: build run test clean
+.PHONY: deps test build
 
 BINARY := event-store
-BUILDFILES := main.go handlers.go
+ORG_PATH := github.com/alphagov
+REPO_PATH := $(ORG_PATH)/$(BINARY)
 
-build: $(BINARY)
+all: test build
 
-run: _vendor
-	gom run $(BUILDFILES)
+build: vendor
+	gom build -o $(BINARY)
 
-test: _vendor
+run: build
+	./$(BINARY)
+
+test: vendor
 	gom test
 
 clean:
-	rm -f $(BINARY)
+	rm -rf bin $(BINARY) _vendor
 
-_vendor: Gomfile
+vendor: deps
+	rm -rf _vendor/src/$(ORG_PATH)
+	mkdir -p _vendor/src/$(ORG_PATH)
+	ln -s $(CURDIR) _vendor/src/$(REPO_PATH)
+
+deps:
 	gom install
-	touch _vendor
-
-$(BINARY): _vendor $(BUILDFILES)
-	gom build -o $(BINARY) $(BUILDFILES)

--- a/event_store_suite_test.go
+++ b/event_store_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestEventStore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EventStore Suite")
+}

--- a/handlers.go
+++ b/handlers.go
@@ -17,7 +17,7 @@ var (
 	mgoSession      *mgo.Session
 	mgoSessionOnce  sync.Once
 	mgoDatabaseName = getenvDefault("EVENT_STORE_MONGO_DB", "event_store")
-	mgoURL          = getenvDefault("EVENT_STORE_MONGO_URL", "localhost")
+	mgoURL          = getenvDefault("EVENT_STORE_MONGO_NODES", "localhost")
 )
 
 type CspReport struct {

--- a/handlers.go
+++ b/handlers.go
@@ -27,15 +27,14 @@ type CspReport struct {
 
 // - DocumentUri: a GOV.UK preview, staging or production URL
 // - Referrer, BlockedUri: may be blank
-// - ViolatedDirective, OriginalPolicy: one or more CSP policies which can
-//   at their most complex contain these characters:
+// - ViolatedDirective: a content security policy which can
+//   at its most complex contain these characters:
 //     default-src: 'self' https://0.example.com *.gov.uk;
 type CspDetails struct {
 	DocumentUri       string `json:"document-uri" bson:"document_uri" validate:"min=1,max=200,regexp=^https://www(\\.preview\\.alphagov\\.co|-origin\\.production\\.alphagov\\.co|\\.gov)\\.uk/[^\\s]*$"`
 	Referrer          string `json:"referrer" bson:"referrer" validate:"max=200"`
 	BlockedUri        string `json:"blocked-uri" bson:"blocked_uri" validate:"max=200"`
 	ViolatedDirective string `json:"violated-directive" bson:"violated_directive" validate:"min=1,max=200,regexp=^[a-z0-9 '/\\*\\.:;-]+$"`
-	OriginalPolicy    string `json:"original-policy" bson:"original_policy" validate:"min=1,max=200"`
 }
 
 // ReportHandler receives JSON from a request body

--- a/handlers.go
+++ b/handlers.go
@@ -20,8 +20,8 @@ var (
 	mgoURL          = getenvDefault("EVENT_STORE_MONGO_NODES", "localhost")
 )
 
-type CspReport struct {
-	Details    CspDetails `json:"csp-report" bson:"csp_report"`
+type CSPReport struct {
+	Details    CSPDetails `json:"csp-report" bson:"csp_report"`
 	ReportTime time.Time  `bson:"date_time"`
 }
 
@@ -30,7 +30,7 @@ type CspReport struct {
 // - ViolatedDirective: a content security policy which can
 //   at its most complex contain these characters:
 //     default-src: 'self' https://0.example.com *.gov.uk;
-type CspDetails struct {
+type CSPDetails struct {
 	DocumentUri       string `json:"document-uri" bson:"document_uri" validate:"min=1,max=200,regexp=^https://www(\\.preview\\.alphagov\\.co|-origin\\.production\\.alphagov\\.co|\\.gov)\\.uk/[^\\s]*$"`
 	Referrer          string `json:"referrer" bson:"referrer" validate:"max=200"`
 	BlockedUri        string `json:"blocked-uri" bson:"blocked_uri" validate:"max=200"`
@@ -40,7 +40,7 @@ type CspDetails struct {
 // ReportHandler receives JSON from a request body
 func ReportHandler(session *mgo.Session) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		var report CspReport
+		var report CSPReport
 
 		if req.Method != "POST" {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Handlers", func() {
 			Expect(response.Code).To(Equal(http.StatusOK))
 
 			collection := session.DB(mgoDatabaseName).C("reports")
-			report := CspReport{}
+			report := CSPReport{}
 
 			Expect(collection.Find(nil).One(&report)).To(BeNil())
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -77,4 +77,25 @@ var _ = Describe("Handlers", func() {
 			Expect(report.Details.DocumentUri).To(Equal("https://www.gov.uk/page"))
 		})
 	})
+
+	Describe("HealthcheckHandler", func() {
+		It("returns a 200 OK when it pings Mongo", func() {
+			request, _ := http.NewRequest("GET", "/healthcheck", nil)
+			response := httptest.NewRecorder()
+
+			HealthcheckHandler(session)(response, request)
+
+			Expect(response.Code).To(Equal(http.StatusOK))
+			Expect(response.Body).To(MatchJSON(`{"mongo": true}`))
+		})
+
+		It("returns Method Not Allowed when not using a GET", func() {
+			request, _ := http.NewRequest("DELETE", "/healthcheck", nil)
+			response := httptest.NewRecorder()
+
+			HealthcheckHandler(session)(response, request)
+
+			Expect(response.Code).To(Equal(http.StatusMethodNotAllowed))
+		})
+	})
 })

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,96 +1,80 @@
-package main
+package main_test
 
 import (
+	. "github.com/alphagov/event-store"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"testing"
-	"time"
 
 	"gopkg.in/mgo.v2"
 )
 
-func TestNonJsonBodyReturnsBadRequest(t *testing.T) {
-	mgoSession := connectToMongo(t)
-	defer mgoSession.DB(mgoDatabaseName).DropDatabase()
+var _ = Describe("Handlers", func() {
+	var session *mgo.Session
+	var err error
+	var mgoDatabaseName = "event_store"
 
-	request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString("Hello"))
-	response := httptest.NewRecorder()
+	BeforeEach(func() {
+		session, err = ConnectToMongo("localhost")
+		Expect(err).To(BeNil())
+	})
 
-	ReportHandler(response, request)
+	AfterEach(func() {
+		session.DB(mgoDatabaseName).DropDatabase()
+		session.Close()
+	})
 
-	if response.Code != http.StatusBadRequest {
-		t.Fatalf("Expected bad request status code, received %v", response.Code)
-	}
-}
+	Describe("ReportHandler", func() {
+		It("should return bad request for non-JSON bodies", func() {
+			request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString("Hello"))
+			response := httptest.NewRecorder()
 
-func TestDocumentUriMustBeOnGovuk(t *testing.T) {
-	mgoSession := connectToMongo(t)
-	defer mgoSession.DB(mgoDatabaseName).DropDatabase()
+			ReportHandler(session)(response, request)
 
-	payload := `{"csp-report": {
-		"document-uri": "https://www.example.com/",
-		"blocked-uri": "https://evil.example.com/",
-		"violated-directive": "directive",
-		"original-policy": "policy"
-	}}`
+			Expect(response.Code).To(Equal(http.StatusBadRequest))
+		})
 
-	request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString(payload))
-	response := httptest.NewRecorder()
+		It("should only accept documents from GOV.UK", func() {
+			payload := `{"csp-report": {
+				"document-uri": "https://www.example.com/",
+				"blocked-uri": "https://evil.example.com/",
+				"violated-directive": "directive",
+				"original-policy": "policy"
+			}}`
 
-	ReportHandler(response, request)
+			request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString(payload))
+			response := httptest.NewRecorder()
 
-	if response.Code != http.StatusBadRequest {
-		t.Fatalf("Expected bad request status code, received %v", response.Code)
-	}
-}
+			ReportHandler(session)(response, request)
 
-func TestValidReportsAreStored(t *testing.T) {
-	mgoSession := connectToMongo(t)
-	defer mgoSession.DB(mgoDatabaseName).DropDatabase()
+			Expect(response.Code).To(Equal(http.StatusBadRequest))
+		})
 
-	payload := `{"csp-report": {
-		"document-uri": "https://www.gov.uk/page",
-		"blocked-uri": "https://evil.example.com/",
-		"violated-directive": "directive",
-		"original-policy": "policy"
-	}}`
+		It("should store valid reports in the database", func() {
+			payload := `{"csp-report": {
+				"document-uri": "https://www.gov.uk/page",
+				"blocked-uri": "https://evil.example.com/",
+				"violated-directive": "directive",
+				"original-policy": "policy"
+			}}`
 
-	request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString(payload))
-	response := httptest.NewRecorder()
+			request, _ := http.NewRequest("POST", "/r", bytes.NewBufferString(payload))
+			response := httptest.NewRecorder()
 
-	ReportHandler(response, request)
+			ReportHandler(session)(response, request)
 
-	if response.Code != http.StatusOK {
-		t.Fatalf("Expected OK status code, received %v", response.Code)
-	}
+			Expect(response.Code).To(Equal(http.StatusOK))
 
-	time.Sleep(100 * time.Millisecond) // Allow the goroutine time to store
+			collection := session.DB(mgoDatabaseName).C("reports")
+			report := CspReport{}
 
-	collection := mgoSession.DB(mgoDatabaseName).C("reports")
-	report := CspReport{}
-	err := collection.Find(nil).One(&report)
+			Expect(collection.Find(nil).One(&report)).To(BeNil())
 
-	if err != nil {
-		t.Fatal("Error when retrieving document from MongoDB")
-	}
-
-	if report.Details.DocumentUri != "https://www.gov.uk/page" {
-		t.Fatalf("Stored report contained unexpected document URI: %v", report.Details.DocumentUri)
-	}
-
-}
-
-func connectToMongo(t *testing.T) (session *mgo.Session) {
-	session, err := mgo.DialWithTimeout("localhost", 200*time.Millisecond)
-
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// Queries return "read tcp 127.0.0.1:27017: i/o timeout" unless
-	// the session socket timeout is increased.
-	session.SetSocketTimeout(1 * time.Second)
-
-	return session
-}
+			Expect(report.Details.DocumentUri).To(Equal("https://www.gov.uk/page"))
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/e", ReportHandler(mgoSession))
+	publicMux.HandleFunc("/healthcheck", HealthcheckHandler(mgoSession))
 
 	log.Println("event-store: listening for events on " + eventPort)
 

--- a/main.go
+++ b/main.go
@@ -5,13 +5,30 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/alext/tablecloth"
+	"gopkg.in/mgo.v2"
 )
 
 var (
 	eventPort = getenvDefault("PORT", "8080")
 )
+
+func ConnectToMongo(hostname string) (*mgo.Session, error) {
+	session, err := mgo.DialWithTimeout(hostname, 200*time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+
+	// Queries return "read tcp 127.0.0.1:27017: i/o timeout" unless
+	// the session socket timeout is increased.
+	session.SetSocketTimeout(1 * time.Second)
+
+	session.SetMode(mgo.Strong, true)
+
+	return session, nil
+}
 
 func getenvDefault(key string, defaultVal string) string {
 	val := os.Getenv(key)
@@ -27,12 +44,14 @@ func main() {
 		tablecloth.WorkingDir = wd
 	}
 
+	mgoSession, err := ConnectToMongo("localhost")
+
 	publicMux := http.NewServeMux()
-	publicMux.HandleFunc("/e", ReportHandler)
+	publicMux.HandleFunc("/e", ReportHandler(mgoSession))
 
 	log.Println("event-store: listening for events on " + eventPort)
 
-	err := tablecloth.ListenAndServe(fmt.Sprintf(":%v", eventPort), publicMux, "reports")
+	err = tablecloth.ListenAndServe(fmt.Sprintf(":%v", eventPort), publicMux, "reports")
 
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	eventPort = getenvDefault("PORT", "8080")
+	eventPort = getenvDefault("PORT", "3097")
 )
 
 func ConnectToMongo(hostname string) (*mgo.Session, error) {


### PR DESCRIPTION
## Add a healtcheck path

Which tests that MongoDB is running and available.
## Don't save the original-policy from the report

The `original-policy` field contains the entire `Content-Security-Policy` header, which will in most cases be very large (so it will fail validation) and mostly not useful.
