### PR TITLE
Catch err from mgo.DialWithTimeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ func main() {
 
 	mgoSession, err := ConnectToMongo(mgoNodes)
 
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/e", ReportHandler(mgoSession))
 	publicMux.HandleFunc("/healthcheck", HealthcheckHandler(mgoSession))


### PR DESCRIPTION
log.Fatal doesn't do much except crash the application, but it's still better than just letting a panic() happen.

I don't know if there's a straightforward way to test this, but I can't find one.
