### PR TITLE
Handle mongo disconnections

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -64,7 +64,10 @@ func ReportHandler(session *mgo.Session) http.HandlerFunc {
 			return
 		}
 
-		collection := session.DB(mgoDatabaseName).C("reports")
+		currentSession := session.Copy()
+		defer currentSession.Close()
+
+		collection := currentSession.DB(mgoDatabaseName).C("reports")
 
 		if err = collection.Insert(report); err != nil {
 			panic(err)
@@ -89,7 +92,10 @@ func HealthcheckHandler(session *mgo.Session) http.HandlerFunc {
 		var status Status
 		var responseCode int
 
-		if session.Ping() == nil {
+		currentSession := session.Copy()
+		defer currentSession.Close()
+
+		if currentSession.Ping() == nil {
 			status.MongoDB = true
 			responseCode = http.StatusOK
 		} else {


### PR DESCRIPTION
Using a single session means that if the connection to mongo is
disrupted, the app will need restarting to work again. This change means
that multiple connections are used, and it will attempt to autoconnect
if there is a problem with mongo.

http://godoc.org/gopkg.in/mgo.v2 describes how “New sessions are
typically created by calling session.Copy on the initial session
obtained at dial time. These new sessions will share the same cluster
information and connection cache, and may be easily handed into other
methods and functions for organizing logic. Every session created must
have its Close method called at the end of its life time, so its
resources may be put back in the pool or collected, depending on the
case.”

So we should call session.Copy to get a new *mgo.Session for each HTTP
request, and mgo will take care of connection pooling for us.

If the server goes away, then https://github.com/go-mgo/mgo/search?utf8=%E2%9C%93&q=AcquireSocket
shows that socket reconnection logic kicks in
https://github.com/go-mgo/mgo/blob/4e47911f9842747e9f9e838ae94a268b8f2404bb/socket.go#L193-L210

There will be _some_ errors, but eventually the app should start working
as MongoDB recovers / comes back online.
