### PR TITLE
Abort on errors connecting to mongo.

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func main() {
 	}
 
 	mgoSession, err := ConnectToMongo(mgoNodes)
+	if err != nil {
+		log.Fatal("Error connectiong to mongo : ", err)
+	}
 
 	publicMux := http.NewServeMux()
 	publicMux.HandleFunc("/e", ReportHandler(mgoSession))


### PR DESCRIPTION
Without this, if mongo is unavailable at startup time, the server will
continue to start, but will never attempt to reconnect. This causes
every request to panic until the server is restarted.
